### PR TITLE
Set up tooling pyproject

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+max_line_length = 100
+
+[*.toml]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.12", "3.13"]
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "1.8.3"
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Cache pip wheels
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/Library/Caches/pip
+            ~\AppData\Local\pip\Cache
+          key: pip-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
+            pip-${{ runner.os }}-
+
+      - name: Install dependencies (with dev)
+        run: poetry install --with dev --no-interaction
+
+      - name: Pre-commit (all files)
+        run: poetry run pre-commit run --all-files
+
+      - name: Ruff (lint)
+        run: poetry run ruff check .
+
+      - name: Ruff (format check)
+        run: poetry run ruff format --check .
+
+      - name: Mypy
+        run: poetry run mypy src tests
+
+      - name: Pytest
+        run: poetry run pytest --cov
+
+      - name: Coverage XML (artifact)
+        run: poetry run coverage xml -o coverage.xml
+
+      - name: Upload coverage.xml
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# Poetry
+poetry.lock
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
@@ -110,9 +113,9 @@ cython_debug/
 .idea/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the enitre vscode folder
  .vscode/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,61 @@
+default_language_version:
+  python: python3.12
+
+ci:
+  autofix_prs: true
+  autoupdate_schedule: monthly
+
+exclude: >
+  (?x)^(
+    \.git/
+    | \.idea/
+    | \.venv/
+    | venv/
+    | build/
+    | dist/
+    | .*\.egg-info/
+    | docs/_build/
+    | coverage\.xml
+    | \.gitignore$
+    | LICENSE$
+    | .*\.md$
+  )$
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: forbid-new-submodules
+      - id: mixed-line-ending
+        args: [ --fix=lf ]
+
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: 2.3.1
+    hooks:
+      - id: pyproject-fmt
+        files: ^pyproject\.toml$
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [ "-L", "crate,te,ba,ans,fo,nd" ]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: ["--fix", "--unsafe-fixes"]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.12.1
+    hooks:
+      - id: mypy
+        args: [ "--config-file=pyproject.toml" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,99 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+
+requires = [ "poetry-core>=1.9" ]
+
+[tool.poetry]
+name = "pysatl-core"
+version = "0.0.1a0"
+description = "Computation core for PySATL"
+readme = "README.md"
+license = "MIT"
+authors = [
+  "Leonid Elkin <yolkinleonwork@gmail.com>",
+  "Mikhail Mikhailov <desiment@yandex.ru>",
+]
+keywords = [
+  "density-functions",
+  "distributions",
+  "mathematics",
+  "numerical-analysis",
+  "probability",
+  "random-variables",
+  "sampling",
+  "scientific-computing",
+  "statistics",
+  "symbolic-computation",
+]
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Typing :: Typed",
+]
+packages = [ { include = "pysatl_core", from = "src" } ]
+include = [
+  { path = "src/pysatl_core/py.typed", format = "wheel" },
+  { path = "src/pysatl_core/py.typed", format = "sdist" },
+]
+homepage = "https://github.com/PySATL/pysatl-core"
+repository = "https://github.com/PySATL/pysatl-core"
+urls.Issues = "https://github.com/PySATL/pysatl-core/issues"
+
+[tool.poetry.dependencies]
+python = ">=3.12"
+
+[tool.poetry.group.dev.dependencies]
+ruff = ">=0.6"
+mypy = ">=1.12"
+pytest = ">=8"
+pytest-cov = ">=5"
+coverage = { version = ">=7.5", extras = [ "toml" ] }
+pre-commit = ">=3.6"
+types-setuptools = "*"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+format.line-ending = "lf"
+
+lint.select = [ "B", "C4", "E", "F", "I", "ISC", "PIE", "SIM", "TID", "UP" ]
+lint.ignore = [ "B008", "E203" ]
+lint.fixable = [ "ALL" ]
+lint.unfixable = [  ]
+
+lint.isort.combine-as-imports = true
+lint.isort.force-single-line = false
+lint.isort.known-first-party = [ "pysatl_core" ]
+lint.isort.order-by-type = true
+
+[tool.pytest.ini_options]
+addopts = "-q --cov=pysatl_core --cov-report=term-missing"
+testpaths = [ "tests" ]
+
+[tool.coverage.run]
+source = [ "pysatl_core" ]
+branch = true
+parallel = true
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+exclude_lines = [
+  "pragma: no cover",
+  "if __name__ == .__main__.:",
+]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_unused_configs = true
+warn_return_any = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+no_implicit_optional = true
+namespace_packages = true
+explicit_package_bases = true
+mypy_path = [ "src" ]

--- a/src/pysatl_core/__init__.py
+++ b/src/pysatl_core/__init__.py
@@ -1,0 +1,4 @@
+from importlib.metadata import version
+
+__version__ = version("pysatl-core")
+__all__ = ["__version__"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,10 @@
+import re
+
+from pysatl_core import __version__
+
+
+def test_version_pep440() -> None:
+    assert re.match(
+        r"^\d+!\d+(\.\d+)*([abc]|rc)?\d*(\.post\d+)?(\.dev\d+)?$|^\d+(\.\d+)*([abc]|rc)?\d*(\.post\d+)?(\.dev\d+)?$",
+        __version__,
+    )


### PR DESCRIPTION
Подготовка всех необходимых тулзов для рабочего пайплана. С ними можно ознакомиться в `pyproject.toml`. Краткая сводка по ним:
- ruff - форматтер и линтер
- coverage[toml] - помощник для pytest-cov, чтобы читать настройки из `pyproject.toml`
- mypy - жесткий чек типов(возможно будет ослаблен или убран)
- pre-commit - чеклист перед коммит
- pytest - тесты
- pytest-cov - покрытие
- poetry - сборка пакетов


Помимо этого были представлены наметки CI 