### PR TITLE
ci: exclude .ipynb files from codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+        exclude: '.*\.ipynb'
         args: [ "-L", "crate,te,ba,ans,fo,nd" ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Codespell currently do not support notebooks with images. Current solution is to just ignore .ipynb files, in future I guess we want something smarter

https://stackoverflow.com/questions/78867158/how-to-make-codespell-not-report-false-positives-in-base64-strings