### PR TITLE
ci: remove mypy checks on tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,3 +66,4 @@ repos:
           - numpy>=2
           - scipy>=1.13
           - pytest>=8
+        exclude: '^tests/.*'


### PR DESCRIPTION
Remove mypy checks on tests, because it is not really understands, e.g., ``with pytest.raise``