### PR TITLE
Score function for builtins

### DIFF
--- a/src/pysatl_core/families/builtins/continuous/exponential.py
+++ b/src/pysatl_core/families/builtins/continuous/exponential.py
@@ -223,6 +223,38 @@ def configure_exponential_family() -> None:
         """Support of exponential distribution"""
         return ContinuousSupport(left=0.0)
 
+    def _base_score(parameters: Parametrization, x: NumericArray) -> NumericArray:
+        """
+        Compute the score (gradient of log‑PDF) for the base parametrization (rate λ).
+
+        For exponential distribution with rate λ > 0, log‑PDF is:
+            log f(x) = log λ - λ x   for x ≥ 0, else -∞.
+
+        The derivative with respect to λ is:
+            ∂/∂λ log f = 1/λ - x   (for x ≥ 0).
+
+        For points x < 0 the density is zero; we return 0 for numerical stability
+        (though the score is technically undefined there).
+
+        Parameters
+        ----------
+        parameters : Parametrization
+            Base parametrization instance (_Rate) with field lambda_.
+        x : NumericArray
+            Points at which to evaluate the gradient.
+
+        Returns
+        -------
+        NumericArray
+            Gradient array of shape (..., 1) where the last axis corresponds to
+            d(log f)/d(lambda_).
+        """
+        params = cast(_Rate, parameters)
+        lam = params.lambda_
+        inside = x >= 0
+        grad = np.where(inside, 1.0 / lam - x, 0.0)
+        return grad[..., np.newaxis]  # shape (..., 1)
+
     Exponential = ParametricFamily(
         name=FamilyName.EXPONENTIAL,
         distr_type=UnivariateContinuous,
@@ -239,6 +271,7 @@ def configure_exponential_family() -> None:
             CharacteristicName.KURT: kurt_func,
         },
         support_by_parametrization=_support,
+        base_score=_base_score,
     )
     Exponential.__doc__ = EXPONENTIAL_DOC
 
@@ -288,5 +321,28 @@ def configure_exponential_family() -> None:
                 Rate parametrization instance
             """
             return _Rate(lambda_=1.0 / self.beta)
+
+        def gradient_transform(self, grad_base: NumericArray) -> NumericArray:
+            """
+            Transform gradient from base parameter (rate λ) to scale β = 1/λ.
+
+            The transformation is: β = 1/λ.
+            Derivative: dβ/dλ = -1/λ².
+            Hence: grad_β = grad_λ * (-1/λ²) = -grad_λ / λ².
+
+            Parameters
+            ----------
+            grad_base : NumericArray
+                Gradient with respect to λ, shape (..., 1).
+
+            Returns
+            -------
+            NumericArray
+                Gradient with respect to β, shape (..., 1).
+            """
+            lam = 1.0 / self.beta  # λ = 1/β
+            grad_lam = grad_base[..., 0]
+            grad_beta = -grad_lam / (lam * lam)
+            return grad_beta[..., np.newaxis].astype(np.float64)
 
     ParametricFamilyRegister.register(Exponential)

--- a/src/pysatl_core/families/builtins/continuous/normal.py
+++ b/src/pysatl_core/families/builtins/continuous/normal.py
@@ -232,6 +232,36 @@ def configure_normal_family() -> None:
         """Support of normal distribution"""
         return ContinuousSupport()
 
+    def _base_score(parameters: Parametrization, x: NumericArray) -> NumericArray:
+        """
+        Compute the score (gradient of log‑PDF) for the base parametrization.
+
+        The base parametrization uses parameters mu (mean) and sigma (standard deviation).
+        The returned gradient has shape (..., 2) with the last axis corresponding
+        to [d(log f)/d(mu), d(log f)/d(sigma)].
+
+        Parameters
+        ----------
+        parameters : Parametrization
+            Base parametrization instance (must be _MeanStd).
+        x : NumericArray
+            Points at which the gradient is evaluated.
+
+        Returns
+        -------
+        NumericArray
+            Gradient array of shape (..., 2).
+        """
+        params = cast(_MeanStd, parameters)
+        mu = params.mu
+        sigma = params.sigma
+
+        z = (x - mu) / sigma
+
+        grad_mu = z / sigma
+        grad_sigma = (z * z - 1) / sigma
+        return np.stack([grad_mu, grad_sigma], axis=-1)
+
     Normal = ParametricFamily(
         name=FamilyName.NORMAL,
         distr_type=UnivariateContinuous,
@@ -248,6 +278,7 @@ def configure_normal_family() -> None:
             CharacteristicName.KURT: kurt_func,
         },
         support_by_parametrization=_support,
+        base_score=_base_score,
     )
     Normal.__doc__ = NORMAL_DOC
 
@@ -305,6 +336,29 @@ def configure_normal_family() -> None:
             sigma = math.sqrt(self.var)
             return _MeanStd(mu=self.mu, sigma=sigma)
 
+        def gradient_transform(self, grad_base: NumericArray) -> NumericArray:
+            """
+            Transform gradient from base parameters (mu, sigma) to (mu, var).
+
+            The transformation is: var = sigma^2  →  d(var) = 2 sigma d(sigma).
+
+            Parameters
+            ----------
+            grad_base : NumericArray
+                Gradient with respect to (mu, sigma), shape (..., 2).
+
+            Returns
+            -------
+            NumericArray
+                Gradient with respect to (mu, var), shape (..., 2).
+            """
+            sigma = np.sqrt(self.var)
+
+            grad_mu = grad_base[..., 0]
+            grad_sigma = grad_base[..., 1]
+            grad_var = grad_sigma / (2 * sigma)
+            return np.stack([grad_mu, grad_var], axis=-1)
+
     @parametrization(family=Normal, name="meanPrec")
     class _MeanPrec(Parametrization):
         """
@@ -337,6 +391,30 @@ def configure_normal_family() -> None:
             """
             sigma = math.sqrt(1 / self.tau)
             return _MeanStd(mu=self.mu, sigma=sigma)
+
+        def gradient_transform(self, grad_base: NumericArray) -> NumericArray:
+            """
+            Transform gradient from base parameters (mu, sigma) to (mu, tau).
+
+            The transformation is: tau = 1/sigma^2  →  d(tau) = -2 / sigma^3 d(sigma).
+
+            Parameters
+            ----------
+            grad_base : NumericArray
+                Gradient with respect to (mu, sigma), shape (..., 2).
+
+            Returns
+            -------
+            NumericArray
+                Gradient with respect to (mu, tau), shape (..., 2).
+            """
+
+            sigma = 1.0 / np.sqrt(self.tau)
+
+            grad_mu = grad_base[..., 0]
+            grad_sigma = grad_base[..., 1]
+            grad_tau = -grad_sigma * sigma**3 / 2.0
+            return np.stack([grad_mu, grad_tau], axis=-1)
 
     @parametrization(family=Normal, name="exponential")
     class _Exp(Parametrization):
@@ -383,5 +461,37 @@ def configure_normal_family() -> None:
             mu = -self.b / (2 * self.a)
             sigma = math.sqrt(-1 / (2 * self.a))
             return _MeanStd(mu=mu, sigma=sigma)
+
+        def gradient_transform(self, grad_base: NumericArray) -> NumericArray:
+            """
+            Transform gradient from base parameters (mu, sigma) to (a, b).
+
+            The transformation is:
+                mu = -b/(2a),  sigma = sqrt(-1/(2a)).
+            The Jacobian is applied via the chain rule.
+
+            Parameters
+            ----------
+            grad_base : NumericArray
+                Gradient with respect to (mu, sigma), shape (..., 2).
+
+            Returns
+            -------
+            NumericArray
+                Gradient with respect to (a, b), shape (..., 2).
+            """
+            a = self.a
+            b = self.b
+
+            dmu_da = b / (2 * a * a)
+            dmu_db = -1 / (2 * a)
+            dsigma_da = 1 / (2 * np.sqrt(-2 * a**3))
+            dsigma_db = 0.0
+
+            grad_mu = grad_base[..., 0]
+            grad_sigma = grad_base[..., 1]
+            grad_a = grad_mu * dmu_da + grad_sigma * dsigma_da
+            grad_b = grad_mu * dmu_db + grad_sigma * dsigma_db
+            return np.stack([grad_a, grad_b], axis=-1)
 
     ParametricFamilyRegister.register(Normal)

--- a/src/pysatl_core/families/builtins/continuous/uniform.py
+++ b/src/pysatl_core/families/builtins/continuous/uniform.py
@@ -260,6 +260,44 @@ def configure_uniform_family() -> None:
             right_closed=True,
         )
 
+    def _base_score(parameters: Parametrization, x: NumericArray) -> NumericArray:
+        """
+        Compute the score (gradient of log‑PDF) for the base
+        parametrization (lower_bound, upper_bound).
+
+        For uniform distribution on [a, b] with a < b, log‑PDF is:
+            log f(x) = -log(b - a)   for a ≤ x ≤ b, else -∞.
+
+        The gradient with respect to a and b (where defined, i.e., inside the support) is:
+            ∂/∂a log f =  1/(b - a)
+            ∂/∂b log f = -1/(b - a)
+
+        For points outside the support, the gradient is set to 0 (since density is zero,
+        but the score is typically considered undefined; we return 0 for numerical safety).
+
+        Parameters
+        ----------
+        parameters : Parametrization
+            Base parametrization instance (_Standard) with fields lower_bound, upper_bound.
+        x : NumericArray
+            Points at which to evaluate the gradient.
+
+        Returns
+        -------
+        NumericArray
+            Gradient array of shape (..., 2) where last axis corresponds to
+            [d(log f)/d(lower_bound), d(log f)/d(upper_bound)].
+        """
+        params = cast(_Standard, parameters)
+        a = params.lower_bound
+        b = params.upper_bound
+        width = b - a
+
+        inside = (x >= a) & (x <= b)
+        grad_a = np.where(inside, 1.0 / width, 0.0)
+        grad_b = np.where(inside, -1.0 / width, 0.0)
+        return np.stack([grad_a, grad_b], axis=-1)
+
     Uniform = ParametricFamily(
         name=FamilyName.CONTINUOUS_UNIFORM,
         distr_type=UnivariateContinuous,
@@ -276,6 +314,7 @@ def configure_uniform_family() -> None:
             CharacteristicName.KURT: kurt_func,
         },
         support_by_parametrization=_support,
+        base_score=_base_score,
     )
     Uniform.__doc__ = UNIFORM_DOC
 
@@ -333,6 +372,38 @@ def configure_uniform_family() -> None:
             half_width = self.width / 2
             return _Standard(lower_bound=self.mean - half_width, upper_bound=self.mean + half_width)
 
+        def gradient_transform(self, grad_base: NumericArray) -> NumericArray:
+            """
+            Transform gradient from base parameters (a, b) to (mean, width).
+
+            The transformation is:
+                mean = (a + b) / 2
+                width = b - a
+
+            The Jacobian matrix:
+                d(mean)/da = 0.5,   d(mean)/db = 0.5
+                d(width)/da = -1,    d(width)/db = 1
+
+            Hence:
+                grad_mean = 0.5 * (grad_a + grad_b)
+                grad_width = -grad_a + grad_b
+
+            Parameters
+            ----------
+            grad_base : NumericArray
+                Gradient with respect to (a, b), shape (..., 2).
+
+            Returns
+            -------
+            NumericArray
+                Gradient with respect to (mean, width), shape (..., 2).
+            """
+            grad_a = grad_base[..., 0]
+            grad_b = grad_base[..., 1]
+            grad_mean = 0.5 * (grad_a + grad_b)
+            grad_width = -grad_a + grad_b
+            return np.stack([grad_mean, grad_width], axis=-1)
+
     @parametrization(family=Uniform, name="minRange")
     class _MinRange(Parametrization):
         """
@@ -364,5 +435,37 @@ def configure_uniform_family() -> None:
                 Standard parametrization instance
             """
             return _Standard(lower_bound=self.minimum, upper_bound=self.minimum + self.range_val)
+
+        def gradient_transform(self, grad_base: NumericArray) -> NumericArray:
+            """
+            Transform gradient from base parameters (a, b) to (minimum, range_val).
+
+            The transformation is:
+                minimum = a
+                range_val = b - a
+
+            The Jacobian matrix:
+                d(minimum)/da = 1,    d(minimum)/db = 0
+                d(range_val)/da = -1,  d(range_val)/db = 1
+
+            Hence:
+                grad_minimum = grad_a
+                grad_range = -grad_a + grad_b
+
+            Parameters
+            ----------
+            grad_base : NumericArray
+                Gradient with respect to (a, b), shape (..., 2).
+
+            Returns
+            -------
+            NumericArray
+                Gradient with respect to (minimum, range_val), shape (..., 2).
+            """
+            grad_a = grad_base[..., 0]
+            grad_b = grad_base[..., 1]
+            grad_minimum = grad_a
+            grad_range = -grad_a + grad_b
+            return np.stack([grad_minimum, grad_range], axis=-1)
 
     ParametricFamilyRegister.register(Uniform)

--- a/src/pysatl_core/families/parametric_family.py
+++ b/src/pysatl_core/families/parametric_family.py
@@ -17,6 +17,8 @@ from collections.abc import Mapping
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast, dataclass_transform
 
+import numpy as np
+
 from pysatl_core.distributions.computation import AnalyticalComputation
 from pysatl_core.families.distribution import ParametricFamilyDistribution
 from pysatl_core.types import (
@@ -36,6 +38,7 @@ if TYPE_CHECKING:
     from pysatl_core.types import (
         GenericCharacteristicName,
         LabelName,
+        NumericArray,
         ParametrizationName,
     )
 
@@ -101,6 +104,7 @@ class ParametricFamily:
         distr_parametrizations: list[ParametrizationName],
         distr_characteristics: CharacteristicsMap,
         support_by_parametrization: SupportArg = None,
+        base_score: Callable[[Parametrization, NumericArray], NumericArray] | None = None,
     ):
         if not distr_parametrizations:
             raise ValueError(
@@ -116,6 +120,7 @@ class ParametricFamily:
         )
 
         self._support_resolver: SupportResolver = support_by_parametrization or (lambda _p: None)
+        self._base_score = base_score
 
         # Runtime registry of parametrization classes
         self._parametrizations: dict[ParametrizationName, type[Parametrization]] = {}
@@ -417,5 +422,33 @@ class ParametricFamily:
         from pysatl_core.families.parametrizations import parametrization as _param_deco
 
         return _param_deco(family=self, name=name)
+
+    def score(self, parameters: Parametrization, x: NumericArray) -> NumericArray:
+        """
+        Compute the score (gradient of log‑PDF) for the given parametrization.
+
+        Parameters
+        ----------
+        parameters : Parametrization
+            Parametrization instance of the family.
+        x : NumericArray
+            Points at which to evaluate the gradient.
+
+        Returns
+        -------
+        NumericArray
+            Gradient with respect to the parameters of the given parametrization.
+            Shape is (..., d), where d is the number of parameters of the parametrization.
+        """
+        if self._base_score is None:
+            raise ValueError(
+                f"Family '{self.name}' does not provide score (gradient) method. "
+                "Please pass '_base_score' to the constructor."
+            )
+        x_arr = np.atleast_1d(x)
+
+        base_params = parameters.transform_to_base_parametrization()
+        base_grad = self._base_score(base_params, x_arr)
+        return parameters.gradient_transform(base_grad)
 
     __call__ = distribution

--- a/src/pysatl_core/families/parametrizations.py
+++ b/src/pysatl_core/families/parametrizations.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, is_dataclass
 from inspect import isfunction
 from typing import TYPE_CHECKING, dataclass_transform
 
-from pysatl_core.types import ParametrizationName
+from pysatl_core.types import NumericArray, ParametrizationName
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -104,6 +104,23 @@ class Parametrization(ABC):
         if conversion to a different parametrization is needed.
         """
         return self
+
+    def gradient_transform(self, grad_base: NumericArray) -> NumericArray:
+        """
+        Transform gradient from base parameter space to this parametrization.
+
+        Parameters
+        ----------
+        grad_base : NumericLike
+            Gradient with respect to base parameters, shape (..., d_base).
+
+        Returns
+        -------
+        NumericLike
+            Gradient with respect to parameters of this parametrization,
+            shape (..., d_this).
+        """
+        return grad_base
 
 
 def constraint[**P](description: str) -> Callable[[Callable[P, bool]], Callable[P, bool]]:

--- a/tests/unit/families/builtins/continuous/test_exponential.py
+++ b/tests/unit/families/builtins/continuous/test_exponential.py
@@ -219,6 +219,60 @@ class TestExponentialFamily(BaseDistributionTest):
 
         assert dist.support.shape == ContinuousSupportShape1D.RAY_RIGHT
 
+    def test_score_rate_parametrization(self):
+        """Test SCORE for rate parametrization against analytical formula."""
+        lam = 0.5
+        dist = self.exponential_family(lambda_=lam)
+        x = np.array([0.0, 1.0, 2.0, 3.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        expected = (1.0 / lam - x)[..., np.newaxis]  # shape (n,1)
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_scale_parametrization(self):
+        """Test SCORE for scale parametrization via chain rule."""
+        beta = 2.0  # lambda = 0.5
+        dist = self.exponential_family(parametrization_name="scale", beta=beta)
+        x = np.array([0.0, 1.0, 2.0, 3.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        lam = 1.0 / beta
+        base_grad = 1.0 / lam - x
+        expected = -base_grad / (lam * lam)
+        expected = expected[..., np.newaxis]
+
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_numerical_derivative(self):
+        """Compare analytical SCORE with numerical gradient for rate parametrization."""
+        lam = 0.5
+        dist = self.exponential_family(lambda_=lam)
+        x = 1.0
+
+        def logpdf_lam(lam_val: float) -> float:
+            return np.log(lam_val) - lam_val * x if x >= 0 else -np.inf
+
+        eps = 1e-6
+        grad_num = (logpdf_lam(lam + eps) - logpdf_lam(lam - eps)) / (2 * eps)
+
+        grad = dist.family.score(dist.parametrization, np.array([x]))
+        np.testing.assert_allclose(grad[0, 0], grad_num, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "parametrization_name, params",
+        [
+            ("rate", {"lambda_": 0.5}),
+            ("scale", {"beta": 2.0}),
+        ],
+    )
+    def test_score_shape(self, parametrization_name, params):
+        """Test SCORE shape for both parametrizations."""
+        x = np.array([0.0, 1.0, 2.0, 3.0])
+        dist = self.exponential_family(parametrization_name=parametrization_name, **params)
+        grad = dist.family.score(dist.parametrization, x)
+        assert grad.shape == (len(x), 1)
+        assert grad.dtype == float
+
 
 class TestExponentialFamilyEdgeCases(BaseDistributionTest):
     """Test edge cases and error conditions for exponential distribution."""

--- a/tests/unit/families/builtins/continuous/test_normal.py
+++ b/tests/unit/families/builtins/continuous/test_normal.py
@@ -236,6 +236,122 @@ class TestNormalFamily(BaseDistributionTest):
 
         assert dist.support.shape == ContinuousSupportShape1D.REAL_LINE
 
+    def test_score_base_parametrization(self):
+        """Test SCORE for meanStd parametrization against analytical formula."""
+        mu, sigma = 2.0, 1.5
+        dist = self.normal_family(mu=mu, sigma=sigma)
+
+        x = np.array([-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        # Analytical gradients: d/dmu = (x-mu)/sigma^2, d/dsigma = -1/sigma + (x-mu)^2/sigma^3
+        expected_mu = (x - mu) / sigma**2
+        expected_sigma = -1.0 / sigma + (x - mu) ** 2 / sigma**3
+        expected = np.stack([expected_mu, expected_sigma], axis=-1)
+
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_meanVar_parametrization(self):
+        """Test SCORE for meanVar parametrization via chain rule."""
+        mu, var = 2.0, 2.25
+        dist = self.normal_family(parametrization_name="meanVar", mu=mu, var=var)
+
+        x = np.array([-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        # Compute base gradient then transform: var = sigma^2 -> dvar = dsigma / (2*sigma)
+        sigma = np.sqrt(var)
+        base_mu = (x - mu) / sigma**2
+        base_sigma = -1.0 / sigma + (x - mu) ** 2 / sigma**3
+        expected_mu = base_mu
+        expected_var = base_sigma / (2 * sigma)
+        expected = np.stack([expected_mu, expected_var], axis=-1)
+
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_meanPrec_parametrization(self):
+        """Test SCORE for meanPrec parametrization via chain rule."""
+        mu, tau = 2.0, 0.25  # sigma = 2.0, var = 4.0
+        dist = self.normal_family(parametrization_name="meanPrec", mu=mu, tau=tau)
+
+        x = np.array([-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        sigma = 1.0 / np.sqrt(tau)  # = 2.0
+        base_mu = (x - mu) / sigma**2
+        base_sigma = -1.0 / sigma + (x - mu) ** 2 / sigma**3
+        expected_mu = base_mu
+        expected_tau = -base_sigma * sigma**3 / 2.0
+        expected = np.stack([expected_mu, expected_tau], axis=-1)
+
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_exponential_parametrization(self):
+        """Test SCORE for exponential parametrization via chain rule."""
+        # Parameters for N(2, 1.5): a = -1/(2*1.5^2) = -0.222..., b = 2/1.5^2 = 0.888...
+        a = -1.0 / (2 * 1.5**2)
+        b = 2.0 / 1.5**2
+        dist = self.normal_family(parametrization_name="exponential", a=a, b=b)
+
+        x = np.array([-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        # Base gradient
+        mu = 2.0
+        sigma = 1.5
+        base_mu = (x - mu) / sigma**2
+        base_sigma = -1.0 / sigma + (x - mu) ** 2 / sigma**3
+
+        # Jacobian: mu = -b/(2a), sigma = sqrt(-1/(2a))
+        dmu_da = b / (2 * a * a)
+        dmu_db = -1.0 / (2 * a)
+        dsigma_da = 1.0 / (2 * np.sqrt(-2 * a**3))
+        dsigma_db = 0.0
+
+        expected_a = base_mu * dmu_da + base_sigma * dsigma_da
+        expected_b = base_mu * dmu_db + base_sigma * dsigma_db
+        expected = np.stack([expected_a, expected_b], axis=-1)
+
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_numerical_derivative(self):
+        """Compare analytical SCORE with numerical gradient for one parametrization."""
+        mu, sigma = 2.0, 1.5
+        dist = self.normal_family(mu=mu, sigma=sigma)
+        x = 1.0
+
+        def logpdf_mu(mu_val: float) -> float:
+            return norm.logpdf(x, loc=mu_val, scale=sigma)
+
+        def logpdf_sigma(sigma_val: float) -> float:
+            return norm.logpdf(x, loc=mu, scale=sigma_val)
+
+        eps = 1e-6
+        grad_mu_num = (logpdf_mu(mu + eps) - logpdf_mu(mu - eps)) / (2 * eps)
+        grad_sigma_num = (logpdf_sigma(sigma + eps) - logpdf_sigma(sigma - eps)) / (2 * eps)
+
+        grad = dist.family.score(dist.parametrization, np.array([x]))
+        np.testing.assert_allclose(grad[0, 0], grad_mu_num, rtol=1e-5)
+        np.testing.assert_allclose(grad[0, 1], grad_sigma_num, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "parametrization_name, params",
+        [
+            ("meanStd", {"mu": 2.0, "sigma": 1.5}),
+            ("meanVar", {"mu": 2.0, "var": 2.25}),
+            ("meanPrec", {"mu": 2.0, "tau": 0.25}),
+            ("exponential", {"a": -0.2222222222222222, "b": 0.8888888888888888}),
+        ],
+    )
+    def test_score_shape(self, parametrization_name, params):
+        """Test that SCORE returns correct shape for all parametrizations."""
+        x = np.array([-1.0, 0.0, 1.0, 2.0, 3.0])
+        dist = self.normal_family(parametrization_name=parametrization_name, **params)
+        grad = dist.family.score(dist.parametrization, x)
+        assert grad.shape == (len(x), 2)
+        assert grad.dtype == float
+        assert not np.any(np.isnan(grad))
+
 
 class TestNormalFamilyEdgeCases(BaseDistributionTest):
     """Test edge cases and error conditions."""

--- a/tests/unit/families/builtins/continuous/test_uniform.py
+++ b/tests/unit/families/builtins/continuous/test_uniform.py
@@ -244,6 +244,95 @@ class TestUniformFamily(BaseDistributionTest):
 
         assert dist.support.shape == ContinuousSupportShape1D.BOUNDED_INTERVAL
 
+    def test_score_standard_parametrization(self):
+        """Test SCORE for standard parametrization against analytical formula."""
+        a, b = 2.0, 5.0
+        dist = self.uniform_family(lower_bound=a, upper_bound=b)
+        x = np.array([1.0, 2.0, 3.5, 5.0, 6.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        width = b - a
+        inside = (x >= a) & (x <= b)
+        expected = np.stack(
+            [np.where(inside, 1.0 / width, 0.0), np.where(inside, -1.0 / width, 0.0)], axis=-1
+        )
+
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_meanWidth_parametrization(self):
+        """Test SCORE for meanWidth parametrization via chain rule."""
+        mean, width = 3.5, 3.0  # corresponds to a=2, b=5
+        dist = self.uniform_family(parametrization_name="meanWidth", mean=mean, width=width)
+        x = np.array([1.0, 2.0, 3.5, 5.0, 6.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        a, b = 2.0, 5.0
+        inside = (x >= a) & (x <= b)
+        base_grad_a = np.where(inside, 1.0 / 3.0, 0.0)
+        base_grad_b = np.where(inside, -1.0 / 3.0, 0.0)
+        # Transform to (mean, width)
+        expected_mean = 0.5 * (base_grad_a + base_grad_b)
+        expected_width = -base_grad_a + base_grad_b
+        expected = np.stack([expected_mean, expected_width], axis=-1)
+
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_minRange_parametrization(self):
+        """Test SCORE for minRange parametrization via chain rule."""
+        minimum, range_val = 2.0, 3.0  # a=2, b=5
+        dist = self.uniform_family(
+            parametrization_name="minRange", minimum=minimum, range_val=range_val
+        )
+        x = np.array([1.0, 2.0, 3.5, 5.0, 6.0])
+        grad = dist.family.score(dist.parametrization, x)
+
+        a, b = 2.0, 5.0
+        inside = (x >= a) & (x <= b)
+        base_grad_a = np.where(inside, 1.0 / 3.0, 0.0)
+        base_grad_b = np.where(inside, -1.0 / 3.0, 0.0)
+        # Transform to (minimum, range_val)
+        expected_min = base_grad_a
+        expected_range = -base_grad_a + base_grad_b
+        expected = np.stack([expected_min, expected_range], axis=-1)
+
+        np.testing.assert_allclose(grad, expected, rtol=self.CALCULATION_PRECISION)
+
+    def test_score_numerical_derivative(self):
+        """Compare analytical SCORE with numerical gradient for standard parametrization."""
+        a, b = 2.0, 5.0
+        dist = self.uniform_family(lower_bound=a, upper_bound=b)
+        x = 3.5
+
+        def logpdf_a(a_val: float) -> float:
+            return np.log(1.0 / (b - a_val)) if (a_val < b and x >= a_val and x <= b) else -np.inf
+
+        def logpdf_b(b_val: float) -> float:
+            return np.log(1.0 / (b_val - a)) if (a < b_val and x >= a and x <= b_val) else -np.inf
+
+        eps = 1e-6
+        grad_a_num = (logpdf_a(a + eps) - logpdf_a(a - eps)) / (2 * eps)
+        grad_b_num = (logpdf_b(b + eps) - logpdf_b(b - eps)) / (2 * eps)
+
+        grad = dist.family.score(dist.parametrization, np.array([x]))
+        np.testing.assert_allclose(grad[0, 0], grad_a_num, rtol=1e-5)
+        np.testing.assert_allclose(grad[0, 1], grad_b_num, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "parametrization_name, params",
+        [
+            ("standard", {"lower_bound": 2.0, "upper_bound": 5.0}),
+            ("meanWidth", {"mean": 3.5, "width": 3.0}),
+            ("minRange", {"minimum": 2.0, "range_val": 3.0}),
+        ],
+    )
+    def test_score_shape(self, parametrization_name, params):
+        """Test SCORE shape for all uniform parametrizations."""
+        x = np.array([1.0, 2.0, 3.5, 5.0, 6.0])
+        dist = self.uniform_family(parametrization_name=parametrization_name, **params)
+        grad = dist.family.score(dist.parametrization, x)
+        assert grad.shape == (len(x), 2)
+        assert grad.dtype == float
+
 
 class TestUniformFamilyEdgeCases(BaseDistributionTest):
     """Test edge cases and error conditions for uniform distribution."""

--- a/tests/unit/families/test_parameters.py
+++ b/tests/unit/families/test_parameters.py
@@ -4,7 +4,10 @@ __author__ = "Leonid Elkin, Mikhail Mikhailov"
 __copyright__ = "Copyright (c) 2025 PySATL project"
 __license__ = "SPDX-License-Identifier: MIT"
 
+from dataclasses import dataclass
 from typing import Any
+
+import numpy as np
 
 from pysatl_core.families import (
     ParametricFamily,
@@ -12,7 +15,7 @@ from pysatl_core.families import (
     ParametrizationConstraint,
     constraint,
 )
-from pysatl_core.types import UnivariateContinuous
+from pysatl_core.types import NumericArray, UnivariateContinuous
 from tests.unit.families.test_basic import TestBaseFamily
 
 
@@ -73,3 +76,31 @@ class TestParametrizationAPI(TestBaseFamily):
         base_from_alt = family.to_base(alt_params)
         assert isinstance(base_from_alt, BaseCls)
         assert base_from_alt.value == 3.0  # type: ignore[attr-defined]
+
+    def test_gradient_transform_identity_for_base(self) -> None:
+        """Test that base parametrization returns grad_base unchanged."""
+
+        @dataclass
+        class DummyParam(Parametrization):
+            value: float
+
+        params = DummyParam(value=1.0)
+        grad_base: NumericArray = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = params.gradient_transform(grad_base)
+        np.testing.assert_array_equal(result, grad_base)
+
+    def test_gradient_transform_can_be_overridden(self) -> None:
+        """Test that a non-base parametrization can override gradient_transform."""
+
+        @dataclass
+        class ScalingParam(Parametrization):
+            scale: float
+
+            def gradient_transform(self, grad_base: NumericArray) -> NumericArray:
+                return grad_base * self.scale
+
+        params = ScalingParam(scale=2.0)
+        grad_base: NumericArray = np.array([1.0, 2.0, 3.0])
+        result = params.gradient_transform(grad_base)
+        expected: NumericArray = grad_base * 2.0
+        np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
Add score (log‑PDF gradient) for built‑in distribution families

    Implement base_score for the base parametrization of Normal, Exponential, Uniform.

    Add gradient_transform to parametrization classes to propagate gradients via chain rule.

    Provide a unified score method in ParametricFamily that works for all parametrizations.

    Include parametrized tests verifying shape, type, and consistency across parametrizations.