### PR TITLE
View for fixed parameters

### DIFF
--- a/src/pysatl_core/families/parametric_family.py
+++ b/src/pysatl_core/families/parametric_family.py
@@ -15,12 +15,14 @@ __license__ = "SPDX-License-Identifier: MIT"
 import inspect
 from collections.abc import Mapping
 from functools import partial
-from typing import TYPE_CHECKING, Any, cast, dataclass_transform
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, cast, dataclass_transform, overload
 
 import numpy as np
 
 from pysatl_core.distributions.computations.computation import AnalyticalComputation
 from pysatl_core.families.distribution import ParametricFamilyDistribution
+from pysatl_core.families.parametrizations import Parametrization
 from pysatl_core.types import (
     DEFAULT_ANALYTICAL_COMPUTATION_LABEL,
     ComputationFunc,
@@ -32,9 +34,6 @@ if TYPE_CHECKING:
 
     from pysatl_core.distributions.strategies import ComputationStrategy, SamplingStrategy
     from pysatl_core.distributions.support import Support
-    from pysatl_core.families.parametrizations import (
-        Parametrization,
-    )
     from pysatl_core.types import (
         GenericCharacteristicName,
         LabelName,
@@ -450,5 +449,375 @@ class ParametricFamily:
         base_params = parameters.transform_to_base_parametrization()
         base_grad = self._base_score(base_params, x_arr)
         return parameters.gradient_transform(base_grad)
+
+    def view(
+        self,
+        *,
+        parametrization_name: str | None = None,
+        **fixed_params: Any,
+    ) -> PartialParametricFamily:
+        """
+        Create a view of this family with partially fixed parameters.
+
+        Parameters
+        ----------
+        parametrization_name : str, optional
+            Name of the parametrization in which the fixed parameters are given.
+            If not provided, the base parametrization of the family is used.
+        **fixed_params : Any
+            Parameter names and values to fix.
+
+        Returns
+        -------
+        PartialParametricFamily
+            A view that behaves like the original family but with the specified
+            parameters fixed.
+
+        Examples
+        --------
+        >>> uniform = ParametricFamilyRegister.get("uniform")
+        >>> uniform_lower0 = uniform.view(lower_bound=0)
+        >>> dist = uniform_lower0.distribution(upper_bound=1)  # Uniform(0,1)
+        """
+        if parametrization_name is not None and parametrization_name not in self.parametrizations:
+            raise ValueError(
+                f"Unknown parametrization '{parametrization_name}' for family '{self.name}'"
+            )
+        return PartialParametricFamily(
+            base_family=self,
+            fixed_params=fixed_params,
+            parametrization_name=parametrization_name,
+        )
+
+    __call__ = distribution
+
+
+class PartialParametricFamily(ParametricFamily):
+    """
+    View on a parametric family with partially fixed parameters.
+
+    This class represents a parametric family where some parameters have been
+    fixed to specific values. It inherits all behaviour from `ParametricFamily`
+    but restricts the available parametrization to the one in which parameters
+    are fixed. All analytical characteristics are preserved via delegation to
+    the base parametrization of the original family.
+
+    Parameters
+    ----------
+    base_family : ParametricFamily
+        The original parametric family.
+    fixed_params : dict[str, Any]
+        Dictionary of fixed parameter names and their values.
+    parametrization_name : str, optional
+        Name of the parametrization in which the fixed parameters are specified.
+        If not provided, the base parametrization of the family is used.
+
+    Raises
+    ------
+    ValueError
+        If all parameters of the chosen parametrization are fixed (use `.distribution()` directly),
+        or if any fixed parameter name is unknown for that parametrization,
+        or if the parametrization name is not registered in the family.
+    """
+
+    def __init__(
+        self,
+        base_family: ParametricFamily,
+        fixed_params: dict[str, Any],
+        parametrization_name: str | None = None,
+    ) -> None:
+        self._fixed_in_param = parametrization_name or base_family.base_parametrization_name
+        self._base_family = base_family
+        self._param_class = base_family.get_parametrization(self._fixed_in_param)
+        self._fixed_params = fixed_params.copy()
+
+        required_fields = set(getattr(self._param_class, "__dataclass_fields__", {}).keys())
+        # Validate that fixed parameters exist
+        unknown = set(self._fixed_params) - required_fields
+        if unknown:
+            raise ValueError(
+                f"Unknown parameters for parametrization '{self._fixed_in_param}': {unknown}"
+            )
+
+        # Check completeness: if all parameters are fixed, raise an error
+        if required_fields.issubset(fixed_params):
+            raise ValueError(
+                f"All parameters of parametrization '{self._fixed_in_param}' are already fixed. "
+                "Use `.distribution()` directly."
+            )
+
+        # Generate lightweight parametrization with only free fields
+        self._free_param_class = self._create_free_param_class()
+        # Assign __param_name__ and __family__ so that instances have .name and .family
+        self._free_param_class.__param_name__ = self._fixed_in_param
+        self._free_param_class.__family__ = self
+
+        self._free_parameter_names = tuple(
+            name
+            for name in getattr(self._param_class, "__dataclass_fields__", {})
+            if name not in self._fixed_params
+        )
+
+        def _view_distr_type(params: Parametrization) -> DistributionType:
+            canonical = base_family.to_base(params)
+            return base_family._distr_type(canonical)
+
+        view_chars = self._build_view_characteristics(base_family)
+
+        super().__init__(
+            name=base_family._name,
+            distr_type=_view_distr_type,
+            distr_parametrizations=[self._fixed_in_param],
+            distr_characteristics=view_chars,
+            support_by_parametrization=base_family._support_resolver,
+            base_score=base_family._base_score,
+        )
+
+        # Register the parametrization (needed for parent methods)
+        self.register_parametrization(self._fixed_in_param, self._free_param_class)
+
+    def _create_free_param_class(self) -> type[Parametrization]:
+        """Create a parametrization class containing only the free (unfixed) parameters.
+
+        The generated class exposes only the fields that were *not* fixed via
+        :meth:`view`.
+
+        Its :meth:`transform_to_base_parametrization` automatically injects the
+        fixed values and delegates to the conversion logic of the
+        original parametrization class.
+
+        The :meth:`validate` method substitutes
+        the fixed values before running the original validation.
+
+        The :meth:`gradient_transform` method maps a base-parametrization gradient to
+        the subspace of free parameters only.
+
+        Returns
+        -------
+        type[Parametrization]
+            A lightweight parametrization class with only the unfixed fields.
+        """
+        fixed_params = self._fixed_params
+        original_class = self._param_class
+        all_fields = getattr(original_class, "__dataclass_fields__", {})
+        free_field_names = [name for name in all_fields if name not in fixed_params]
+
+        def __init__(self: Parametrization, **kwargs: Any) -> None:
+            unexpected = set(kwargs) - set(free_field_names)
+            if unexpected:
+                raise TypeError(
+                    f"__init__() got unexpected keyword arguments: "
+                    f"{', '.join(repr(u) for u in unexpected)}"
+                )
+            missing = set(free_field_names) - set(kwargs)
+            if missing:
+                raise TypeError(
+                    f"__init__() missing required keyword arguments: "
+                    f"{', '.join(repr(m) for m in missing)}"
+                )
+            for name in free_field_names:
+                object.__setattr__(self, name, kwargs[name])
+
+        def transform_to_base(self: Parametrization) -> Parametrization:
+            """Substitute fixed values and delegate to the original parametrization."""
+            combined = {
+                **fixed_params,
+                **{f: getattr(self, f) for f in free_field_names},
+            }
+            original_instance = original_class(**combined)
+            return original_instance.transform_to_base_parametrization()
+
+        def validate(self: Parametrization) -> None:
+            """Validate by combining fixed and free parameters, then delegating."""
+            combined = {
+                **fixed_params,
+                **{f: getattr(self, f) for f in free_field_names},
+            }
+            original_class(**combined).validate()
+
+        def gradient_transform(self: Parametrization, base_grad: NumericArray) -> NumericArray:
+            """Map a gradient from the base parametrization to free-parameter space.
+
+            The base gradient is first transformed into the original (full)
+            parametrization.  Components that correspond to fixed parameters are
+            then discarded, keeping only the directions of the free parameters.
+            """
+            combined = {
+                **fixed_params,
+                **{f: getattr(self, f) for f in free_field_names},
+            }
+            full_instance = original_class(**combined)
+            full_grad = full_instance.gradient_transform(base_grad)
+            all_field_names = list(all_fields.keys())
+            free_indices = [i for i, name in enumerate(all_field_names) if name in free_field_names]
+            return full_grad[..., free_indices]
+
+        new_class = type(
+            f"{original_class.__name__}Free",
+            (Parametrization,),
+            {
+                "__init__": __init__,
+                "transform_to_base_parametrization": transform_to_base,
+                "validate": validate,
+                "gradient_transform": gradient_transform,
+                "__dataclass_fields__": {name: all_fields[name] for name in free_field_names},
+                "__annotations__": {name: all_fields[name].type for name in free_field_names},
+            },
+        )
+        return new_class
+
+    @property
+    def parametrizations(self) -> dict[str, type[Parametrization]]:
+        """Return a dictionary containing only the fixed (free‑parameter) parametrization."""
+        return {self._fixed_in_param: self._free_param_class}
+
+    @property
+    def parent_family(self) -> ParametricFamily:
+        """Original family this view was created from."""
+        return self._base_family
+
+    @property
+    def fixed_parameters(self) -> Mapping[str, Any]:
+        """Fixed parameter values."""
+        return MappingProxyType(self._fixed_params)
+
+    @property
+    def fixed_parameter_names(self) -> frozenset[str]:
+        """Names of fixed parameters."""
+        return frozenset(self._fixed_params)
+
+    @property
+    def free_parameter_names(self) -> tuple[str, ...]:
+        """Names of parameters that remain free in this view."""
+        return self._free_parameter_names
+
+    @overload
+    def get_parametrization(self) -> type[Parametrization]: ...
+
+    @overload
+    def get_parametrization(self, name: ParametrizationName) -> type[Parametrization]: ...
+
+    def get_parametrization(self, name: ParametrizationName | None = None) -> type[Parametrization]:
+        """Return the lightweight parametrization class with only free parameters.
+
+        If `name` is omitted, returns the fixed parametrization class.
+        If `name` is given, it must match the fixed parametrization name.
+
+        Raises KeyError for any other name.
+        """
+        if name is None:
+            return self._free_param_class
+        if name != self._fixed_in_param:
+            raise KeyError(
+                f"Parametrization '{name}' is not available in this view. "
+                f"Only '{self._fixed_in_param}' is available."
+            )
+        return self._free_param_class
+
+    @property
+    def base(self) -> type[Parametrization]:
+        """Return a lightweight parametrization class with only free parameters.
+
+        Its ``transform_to_base_parametrization`` substitutes fixed values and
+        delegates to the original parametrization.
+        """
+        return self._free_param_class
+
+    def to_base(self, parameters: Parametrization) -> Parametrization:
+        """Convert view parameters to the original family's base parametrization.
+        The view's own base is the lightweight class, but the true base is the
+        original family's base. We always transform through the full parametrization.
+        """
+        return parameters.transform_to_base_parametrization()
+
+    def _build_view_characteristics(self, base_family: ParametricFamily) -> dict[str, Any]:
+        view_chars = {}
+        original_base = base_family.base_parametrization_name
+
+        def wrap_provider(
+            provider: ParametricFamilyCharacteristic[Any, Any],
+        ) -> ParametricFamilyCharacteristic[Any, Any]:
+            def wrapped(params: Parametrization, *args: Any, **kwargs: Any) -> Any:
+                base_params = base_family.to_base(params)
+                bound = ParametricFamily._bind_parametrization(provider, base_params)
+                return bound(*args, **kwargs)
+
+            return wrapped
+
+        def wrap_fixed_provider(
+            provider: ParametricFamilyCharacteristic[Any, Any],
+        ) -> ParametricFamilyCharacteristic[Any, Any]:
+            def wrapped(params: Parametrization, *args: Any, **kwargs: Any) -> Any:
+                combined = {
+                    **self._fixed_params,
+                    **{f: getattr(params, f) for f in self.free_parameter_names},
+                }
+                full_params = self._param_class(**combined)
+                bound = ParametricFamily._bind_parametrization(provider, full_params)
+                return bound(*args, **kwargs)
+
+            return wrapped
+
+        for char_name, char_map in base_family.distr_characteristics.items():
+            if self._fixed_in_param in char_map:
+                providers = char_map[self._fixed_in_param]
+                wrapped_providers = {
+                    label: wrap_fixed_provider(provider) if callable(provider) else provider
+                    for label, provider in providers.items()
+                }
+                view_chars[char_name] = {self._fixed_in_param: wrapped_providers}
+            elif original_base in char_map:
+                original_provider = char_map[original_base]
+                wrapped = {
+                    label: wrap_provider(provider) if callable(provider) else provider
+                    for label, provider in original_provider.items()
+                }
+                view_chars[char_name] = {self._fixed_in_param: wrapped}
+
+        return view_chars
+
+    def distribution(
+        self,
+        parametrization_name: str | None = None,
+        sampling_strategy: SamplingStrategy | None = None,
+        computation_strategy: ComputationStrategy | None = None,
+        **kwargs: Any,
+    ) -> ParametricFamilyDistribution:
+        target = parametrization_name or self._fixed_in_param
+        if target != self._fixed_in_param:
+            raise ValueError(
+                f"Only parametrization '{self._fixed_in_param}' is available in this view. "
+                "Please omit 'parametrization_name' or use the fixed one."
+            )
+        for key, fixed_val in self._fixed_params.items():
+            if key in kwargs and kwargs[key] != fixed_val:
+                raise ValueError(
+                    f"Parameter '{key}' is fixed to {fixed_val}, but got {kwargs[key]}"
+                )
+        return super().distribution(
+            parametrization_name=target,
+            sampling_strategy=sampling_strategy,
+            computation_strategy=computation_strategy,
+            **kwargs,
+        )
+
+    def view(
+        self,
+        *,
+        parametrization_name: str | None = None,
+        **additional_params: Any,
+    ) -> PartialParametricFamily:
+        if parametrization_name is not None and parametrization_name != self._fixed_in_param:
+            raise ValueError(
+                f"Cannot change parametrization. Current fixed parametrization is "
+                f"'{self._fixed_in_param}'. Use the same or omit the argument."
+            )
+        for key, fixed_val in self._fixed_params.items():
+            if key in additional_params and additional_params[key] != fixed_val:
+                raise ValueError(
+                    f"Parameter '{key}' is fixed to {fixed_val}, but got {additional_params[key]}"
+                )
+        new_fixed = {**self._fixed_params, **additional_params}
+        return PartialParametricFamily(self._base_family, new_fixed, self._fixed_in_param)
 
     __call__ = distribution

--- a/src/pysatl_core/families/parametric_family.py
+++ b/src/pysatl_core/families/parametric_family.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from pysatl_core.distributions.computations.computation import AnalyticalComputation
 from pysatl_core.families.distribution import ParametricFamilyDistribution
-from pysatl_core.families.parametrizations import Parametrization
+from pysatl_core.families.parametrizations import Parametrization, ParametrizationConstraint
 from pysatl_core.types import (
     DEFAULT_ANALYTICAL_COMPUTATION_LABEL,
     ComputationFunc,
@@ -546,21 +546,25 @@ class PartialParametricFamily(ParametricFamily):
                 "Use `.distribution()` directly."
             )
 
-        # Generate lightweight parametrization with only free fields
-        self._free_param_class = self._create_free_param_class()
-        # Assign __param_name__ and __family__ so that instances have .name and .family
-        self._free_param_class.__param_name__ = self._fixed_in_param
-        self._free_param_class.__family__ = self
-
         self._free_parameter_names = tuple(
             name
             for name in getattr(self._param_class, "__dataclass_fields__", {})
             if name not in self._fixed_params
         )
 
+        # Generate lightweight parametrization with only free fields
+        self._free_param_class = self._create_free_param_class()
+        # Assign __param_name__ and __family__ so that instances have .name and .family
+        self._free_param_class.__param_name__ = self._fixed_in_param
+        self._free_param_class.__family__ = self
+
         def _view_distr_type(params: Parametrization) -> DistributionType:
             canonical = base_family.to_base(params)
             return base_family._distr_type(canonical)
+
+        def _view_support(params: Parametrization) -> Support | None:
+            full_params = self._to_full_parametrization(params)
+            return base_family.support_resolver(full_params)
 
         view_chars = self._build_view_characteristics(base_family)
 
@@ -569,12 +573,20 @@ class PartialParametricFamily(ParametricFamily):
             distr_type=_view_distr_type,
             distr_parametrizations=[self._fixed_in_param],
             distr_characteristics=view_chars,
-            support_by_parametrization=base_family._support_resolver,
+            support_by_parametrization=_view_support,
             base_score=base_family._base_score,
         )
 
         # Register the parametrization (needed for parent methods)
         self.register_parametrization(self._fixed_in_param, self._free_param_class)
+
+    def _to_full_parametrization(self, params: Parametrization) -> Parametrization:
+        """Reconstruct the original parametrization by injecting fixed parameters."""
+        combined = {
+            **self._fixed_params,
+            **{name: getattr(params, name) for name in self._free_parameter_names},
+        }
+        return self._param_class(**combined)
 
     def _create_free_param_class(self) -> type[Parametrization]:
         """Create a parametrization class containing only the free (unfixed) parameters.
@@ -597,10 +609,10 @@ class PartialParametricFamily(ParametricFamily):
         type[Parametrization]
             A lightweight parametrization class with only the unfixed fields.
         """
-        fixed_params = self._fixed_params
         original_class = self._param_class
         all_fields = getattr(original_class, "__dataclass_fields__", {})
-        free_field_names = [name for name in all_fields if name not in fixed_params]
+        free_field_names = list(self._free_parameter_names)
+        partial_family = self
 
         def __init__(self: Parametrization, **kwargs: Any) -> None:
             unexpected = set(kwargs) - set(free_field_names)
@@ -620,20 +632,12 @@ class PartialParametricFamily(ParametricFamily):
 
         def transform_to_base(self: Parametrization) -> Parametrization:
             """Substitute fixed values and delegate to the original parametrization."""
-            combined = {
-                **fixed_params,
-                **{f: getattr(self, f) for f in free_field_names},
-            }
-            original_instance = original_class(**combined)
-            return original_instance.transform_to_base_parametrization()
+            full_params = partial_family._to_full_parametrization(self)
+            return full_params.transform_to_base_parametrization()
 
         def validate(self: Parametrization) -> None:
             """Validate by combining fixed and free parameters, then delegating."""
-            combined = {
-                **fixed_params,
-                **{f: getattr(self, f) for f in free_field_names},
-            }
-            original_class(**combined).validate()
+            partial_family._to_full_parametrization(self).validate()
 
         def gradient_transform(self: Parametrization, base_grad: NumericArray) -> NumericArray:
             """Map a gradient from the base parametrization to free-parameter space.
@@ -642,15 +646,27 @@ class PartialParametricFamily(ParametricFamily):
             parametrization.  Components that correspond to fixed parameters are
             then discarded, keeping only the directions of the free parameters.
             """
-            combined = {
-                **fixed_params,
-                **{f: getattr(self, f) for f in free_field_names},
-            }
-            full_instance = original_class(**combined)
+            full_instance = partial_family._to_full_parametrization(self)
             full_grad = full_instance.gradient_transform(base_grad)
             all_field_names = list(all_fields.keys())
             free_indices = [i for i, name in enumerate(all_field_names) if name in free_field_names]
             return full_grad[..., free_indices]
+
+        def adapt_constraint(
+            original_constraint: ParametrizationConstraint,
+        ) -> ParametrizationConstraint:
+            def check(params: Parametrization) -> bool:
+                return original_constraint.check(partial_family._to_full_parametrization(params))
+
+            return ParametrizationConstraint(
+                description=original_constraint.description,
+                check=check,
+            )
+
+        adapted_constraints = [
+            adapt_constraint(constraint)
+            for constraint in getattr(original_class, "_constraints", [])
+        ]
 
         new_class = type(
             f"{original_class.__name__}Free",
@@ -662,6 +678,7 @@ class PartialParametricFamily(ParametricFamily):
                 "gradient_transform": gradient_transform,
                 "__dataclass_fields__": {name: all_fields[name] for name in free_field_names},
                 "__annotations__": {name: all_fields[name].type for name in free_field_names},
+                "_constraints": adapted_constraints,
             },
         )
         return new_class
@@ -728,7 +745,7 @@ class PartialParametricFamily(ParametricFamily):
         The view's own base is the lightweight class, but the true base is the
         original family's base. We always transform through the full parametrization.
         """
-        return parameters.transform_to_base_parametrization()
+        return self._base_family.to_base(self._to_full_parametrization(parameters))
 
     def _build_view_characteristics(self, base_family: ParametricFamily) -> dict[str, Any]:
         view_chars = {}
@@ -748,11 +765,7 @@ class PartialParametricFamily(ParametricFamily):
             provider: ParametricFamilyCharacteristic[Any, Any],
         ) -> ParametricFamilyCharacteristic[Any, Any]:
             def wrapped(params: Parametrization, *args: Any, **kwargs: Any) -> Any:
-                combined = {
-                    **self._fixed_params,
-                    **{f: getattr(params, f) for f in self.free_parameter_names},
-                }
-                full_params = self._param_class(**combined)
+                full_params = self._to_full_parametrization(params)
                 bound = ParametricFamily._bind_parametrization(provider, full_params)
                 return bound(*args, **kwargs)
 

--- a/tests/unit/families/test_partial_family.py
+++ b/tests/unit/families/test_partial_family.py
@@ -11,8 +11,9 @@ import numpy as np
 import pytest
 
 from pysatl_core.distributions.strategies import DefaultComputationStrategy
+from pysatl_core.distributions.support import ContinuousSupport
 from pysatl_core.families.parametric_family import ParametricFamily, PartialParametricFamily
-from pysatl_core.families.parametrizations import Parametrization
+from pysatl_core.families.parametrizations import Parametrization, constraint
 from pysatl_core.sampling.default import DefaultSamplingUnivariateStrategy
 from pysatl_core.types import (
     CharacteristicName,
@@ -175,6 +176,53 @@ class TestPartialParametricFamily(TestBaseFamily):
         )
         assert dist.sampling_strategy is sampling
         assert dist.computation_strategy is computation
+
+    def test_support_resolver_receives_full_original_parametrization(self) -> None:
+        def support(params: Parametrization) -> ContinuousSupport:
+            full_params = cast(TwoParam, params)
+            return ContinuousSupport(full_params.a, full_params.b)
+
+        fam = ParametricFamily(
+            name="SupportDependsOnParams",
+            distr_type=UnivariateContinuous,
+            distr_parametrizations=["base"],
+            distr_characteristics={
+                CharacteristicName.PDF: {"base": {"default": lambda p, x: p.a + p.b}},
+            },
+            support_by_parametrization=support,
+        )
+        fam.register_parametrization("base", TwoParam)
+
+        dist = fam.view(a=1.0).distribution(b=3.0)
+
+        assert dist.support == ContinuousSupport(1.0, 3.0)
+
+    def test_partial_distribution_preserves_adapted_constraints(self) -> None:
+        fam = ParametricFamily(
+            name="ConstrainedFamily",
+            distr_type=UnivariateContinuous,
+            distr_parametrizations=["base"],
+            distr_characteristics={
+                CharacteristicName.PDF: {"base": {"default": lambda p, x: p.a + p.b}},
+            },
+        )
+
+        @fam.parametrization(name="base")
+        class OrderedParams(Parametrization):
+            a: float
+            b: float
+
+            @constraint(description="a < b")
+            def check_order(self) -> bool:
+                return self.a < self.b
+
+        dist = fam.view(a=1.0).distribution(b=3.0)
+
+        assert [c.description for c in dist.parameters_constraints] == ["a < b"]
+        assert all(c.check(dist.parametrization) for c in dist.parameters_constraints)
+
+        with pytest.raises(ValueError, match='Constraint "a < b" does not hold'):
+            fam.view(a=3.0).distribution(b=1.0)
 
     # Chaining view
     def test_view_on_view_creates_new_view_until_complete(self) -> None:

--- a/tests/unit/families/test_partial_family.py
+++ b/tests/unit/families/test_partial_family.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+__author__ = "Myznikov Fedor"
+__copyright__ = "Copyright (c) 2025 PySATL project"
+__license__ = "SPDX-License-Identifier: MIT"
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from pysatl_core.distributions.strategies import DefaultComputationStrategy
+from pysatl_core.families.parametric_family import ParametricFamily, PartialParametricFamily
+from pysatl_core.families.parametrizations import Parametrization
+from pysatl_core.sampling.default import DefaultSamplingUnivariateStrategy
+from pysatl_core.types import (
+    CharacteristicName,
+    DistributionType,
+    UnivariateContinuous,
+    UnivariateDiscrete,
+)
+from tests.unit.families.test_basic import TestBaseFamily
+
+
+@dataclass
+class TwoParam(Parametrization):
+    a: float
+    b: float
+
+    def transform_to_base_parametrization(self) -> Parametrization:
+        return self
+
+
+TwoParam.__param_name__ = "base"
+
+
+@dataclass
+class AltParam(Parametrization):
+    mean: float
+    var: float
+
+    def transform_to_base_parametrization(self) -> TwoParam:
+        return TwoParam(a=self.mean, b=self.var)
+
+
+AltParam.__param_name__ = "alt"
+
+
+@dataclass
+class TypeSwitchingParams(Parametrization):
+    a: float
+    b: float
+
+    def transform_to_base_parametrization(self) -> Parametrization:
+        return self
+
+
+TypeSwitchingParams.__param_name__ = "base"
+
+
+class TestPartialParametricFamily(TestBaseFamily):
+    """Tests for PartialParametricFamily view with partially fixed parameters."""
+
+    def _make_two_param_family(self) -> ParametricFamily:
+        fam = ParametricFamily(
+            name="TwoParamFamily",
+            distr_type=UnivariateContinuous,
+            distr_parametrizations=["base"],
+            distr_characteristics={
+                CharacteristicName.PDF: {"base": {"default": lambda p, x: p.a + p.b}},
+                CharacteristicName.CDF: {"base": {"default": lambda p, x: p.a}},
+            },
+        )
+        fam.register_parametrization("base", TwoParam)
+        return fam
+
+    def test_view_returns_partial_family(self) -> None:
+        fam = self.make_default_family()
+        partial = fam.view()
+        assert isinstance(partial, PartialParametricFamily)
+        assert partial._base_family is fam
+        assert partial._fixed_params == {}
+        assert partial._fixed_in_param == fam.base_parametrization_name
+
+    def test_view_with_explicit_parametrization(self) -> None:
+        fam = self.make_default_family()
+        partial = fam.view(parametrization_name="alt")
+        assert partial._fixed_in_param == "alt"
+        assert partial._fixed_params == {}
+
+    def test_view_with_partial_fixation(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        assert partial._fixed_params == {"a": 2.0}
+        assert partial._fixed_in_param == "base"
+
+    def test_full_fixation_raises(self) -> None:
+        fam = self._make_two_param_family()
+        with pytest.raises(
+            ValueError, match="All parameters of parametrization 'base' are already fixed"
+        ):
+            fam.view(a=1.0, b=2.0)
+
+    def test_unknown_parameter_raises(self) -> None:
+        fam = self._make_two_param_family()
+        with pytest.raises(ValueError, match="Unknown parameters for parametrization 'base':"):
+            fam.view(a=1.0, unknown=42)
+
+    # Properties (parent_family, fixed/free parameter info)
+    def test_parent_family(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        assert partial.parent_family is fam
+
+    def test_fixed_parameters(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        assert partial.fixed_parameters == {"a": 2.0}
+        # MappingProxyType does not allow modification
+        with pytest.raises(TypeError):
+            partial.fixed_parameters["a"] = 3.0  # type: ignore[index]
+
+    def test_fixed_parameter_names(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        assert partial.fixed_parameter_names == frozenset({"a"})
+
+    def test_free_parameter_names(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        assert partial.free_parameter_names == ("b",)
+
+    # distribution()
+    def test_distribution_uses_fixed_parameters(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        dist = partial.distribution(b=3.0)
+        params = cast(Any, dist.parametrization)
+        assert params.b == 3.0
+        assert partial.fixed_parameters == {"a": 2.0}
+
+    def test_distribution_raises_on_conflicting_values(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        with pytest.raises(ValueError, match="Parameter 'a' is fixed to 2.0, but got 5.0"):
+            partial.distribution(a=5.0, b=1.0)
+
+    def test_distribution_rejects_fixed_param_even_if_correct_value(self) -> None:
+        """Passing a fixed parameter (even with the correct value) is not allowed
+        because the lightweight parametrization class does not accept it."""
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        with pytest.raises(TypeError):
+            partial.distribution(a=2.0, b=3.0)
+
+    def test_distribution_raises_on_different_parametrization(self) -> None:
+        fam = self.make_default_family()
+        partial = fam.view(parametrization_name="base")
+        with pytest.raises(
+            ValueError,
+            match="Only parametrization 'base' is available in this view.",
+        ):
+            partial.distribution(parametrization_name="alt")
+
+    def test_distribution_passes_sampling_and_computation_strategies(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=1.0)
+        sampling = DefaultSamplingUnivariateStrategy()
+        computation = DefaultComputationStrategy()
+        dist = partial.distribution(
+            b=2.0,
+            sampling_strategy=sampling,
+            computation_strategy=computation,
+        )
+        assert dist.sampling_strategy is sampling
+        assert dist.computation_strategy is computation
+
+    # Chaining view
+    def test_view_on_view_creates_new_view_until_complete(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=1.0)
+        assert partial._fixed_params == {"a": 1.0}
+        with pytest.raises(
+            ValueError, match="All parameters of parametrization 'base' are already fixed"
+        ):
+            partial.view(b=2.0)
+        dist = partial.distribution(b=2.0)
+        params = cast(Any, dist.parametrization)
+        assert params.b == 2.0
+        assert partial.fixed_parameters == {"a": 1.0}
+
+    # Parametrization access (base, parametrizations, get_parametrization)
+    def test_only_fixed_parametrization_visible(self) -> None:
+        fam = self.make_default_family()
+        partial = fam.view(parametrization_name="alt")
+        assert partial.parametrization_names == ["alt"]
+        assert partial.base_parametrization_name == "alt"
+        assert list(partial.parametrizations.keys()) == ["alt"]
+        # The registered class is the lightweight one, not the original
+        assert partial.get_parametrization("alt") is partial.base
+        with pytest.raises(KeyError, match="Parametrization 'base' is not available"):
+            partial.get_parametrization("base")
+
+    def test_get_parametrization_without_name(self) -> None:
+        fam = self.make_default_family()
+        partial = fam.view(parametrization_name="alt")
+        assert partial.get_parametrization() is partial.base
+
+    def test_base_is_free_param_class(self) -> None:
+        """base returns a class that contains only the free fields."""
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        free_cls = partial.base
+        fields = getattr(free_cls, "__dataclass_fields__", {})
+        assert "b" in fields
+        assert "a" not in fields
+
+    # Inherited attributes
+    def test_inherited_attributes_and_methods(self) -> None:
+        fam = self.make_default_family()
+        partial = fam.view()
+        assert partial.name == fam.name
+        assert partial.base is not None
+        assert list(partial.parametrizations.keys()) == ["base"]
+        assert partial.get_parametrization("base") is partial.base
+        with pytest.raises(KeyError):
+            partial.get_parametrization("alt")
+
+    # __call__
+    def test_callable_interface(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        dist = partial(b=3.0)
+        params = cast(Any, dist.parametrization)
+        assert params.b == 3.0
+        assert partial.fixed_parameters == {"a": 2.0}
+        with pytest.raises(ValueError, match="Parameter 'a' is fixed to 2.0, but got 4.0"):
+            partial(a=4.0, b=1.0)
+
+    # Analytical characteristics
+    def test_analytical_characteristics_preserved(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=2.0)
+        dist = partial.distribution(b=3.0)
+        pdf_val = dist.calculate_characteristic(CharacteristicName.PDF, 0.0)
+        assert pdf_val == 5.0
+
+    def test_analytical_characteristics_with_non_base_fixation(self) -> None:
+        fam = ParametricFamily(
+            name="Test",
+            distr_type=UnivariateContinuous,
+            distr_parametrizations=["base", "alt"],
+            distr_characteristics={
+                CharacteristicName.PDF: {
+                    "base": {"default": lambda p, x: p.a + p.b},
+                },
+                CharacteristicName.CDF: {
+                    "alt": {"default": lambda p, x: p.mean},
+                },
+            },
+            support_by_parametrization=None,
+            base_score=None,
+        )
+        fam.register_parametrization("base", TwoParam)
+        fam.register_parametrization("alt", AltParam)
+
+        partial = fam.view(parametrization_name="alt", mean=2.0)
+        dist = partial.distribution(var=3.0)
+
+        pdf_val = dist.calculate_characteristic(CharacteristicName.PDF, 0.0)
+        assert pdf_val == 5.0
+
+        cdf_val = dist.calculate_characteristic(CharacteristicName.CDF, 0.0)
+        assert cdf_val == 2.0
+
+    def test_characteristic_with_nullary_provider_is_wrapped_correctly(self) -> None:
+        """A characteristic that does not accept a parametrization argument
+        (e.g., skew) must work through the wrapper that uses _bind_parametrization."""
+        fam = ParametricFamily(
+            name="SkewFamily",
+            distr_type=UnivariateContinuous,
+            distr_parametrizations=["base", "alt"],
+            distr_characteristics={
+                CharacteristicName.SKEW: {
+                    "base": {"default": lambda *, excess=False: 0.0 if not excess else -3.0},
+                },
+            },
+            support_by_parametrization=None,
+            base_score=None,
+        )
+        fam.register_parametrization("base", TwoParam)
+        fam.register_parametrization("alt", AltParam)
+
+        partial = fam.view(parametrization_name="alt", mean=2.0)
+        dist = partial.distribution(var=3.0)
+
+        skew_func = dist.query_method(CharacteristicName.SKEW)
+        val = skew_func()
+        val_excess = skew_func(excess=True)
+        assert val == 0.0
+        assert val_excess == -3.0
+
+    # distr_type wrapping
+    def test_distr_type_wrapped_with_dynamic_type(self) -> None:
+        def dynamic_type(params: Parametrization) -> DistributionType:
+            p = cast(TypeSwitchingParams, params)
+            return UnivariateContinuous if p.a > 0 else UnivariateDiscrete
+
+        fam = ParametricFamily(
+            name="DynamicType",
+            distr_type=dynamic_type,
+            distr_parametrizations=["base"],
+            distr_characteristics={
+                CharacteristicName.PDF: {"base": {"default": lambda p, x: p.a + p.b}},
+            },
+        )
+        fam.register_parametrization("base", TypeSwitchingParams)
+
+        partial = fam.view(a=2.0)
+        dist = partial.distribution(b=3.0)
+        assert dist.distribution_type == UnivariateContinuous
+
+        partial_neg = fam.view(a=-1.0)
+        dist_neg = partial_neg.distribution(b=3.0)
+        assert dist_neg.distribution_type == UnivariateDiscrete
+
+    # score / gradient_transform
+    def test_score_returns_gradient_wrt_free_parameters_only(self) -> None:
+        """score() must return an array whose last dimension equals the number of
+        free parameters."""
+
+        # Use a simple family with base_score computed via base parametrization.
+        def base_score(params: Parametrization, x: np.ndarray) -> np.ndarray:
+            cast(TwoParam, params)
+            # Dummy gradient: shape (..., 2)
+            return np.broadcast_to(np.array([1.0, 2.0]), (*x.shape, 2))
+
+        fam = ParametricFamily(
+            name="ScoreTest",
+            distr_type=UnivariateContinuous,
+            distr_parametrizations=["base", "alt"],
+            distr_characteristics={
+                CharacteristicName.PDF: {"base": {"default": lambda p, x: np.zeros_like(x)}}
+            },
+            base_score=base_score,
+        )
+        fam.register_parametrization("base", TwoParam)
+        fam.register_parametrization("alt", AltParam)
+
+        partial = fam.view(parametrization_name="alt", mean=2.0)
+        free_params = partial.distribution(var=3.0).parametrization
+        grad = partial.score(free_params, np.array([0.5]))
+        assert grad.shape == (1, 1)  # only 'var' is free
+        np.testing.assert_array_almost_equal(grad, [[2.0]])
+
+    def test_view_unknown_parametrization_raises_in_base(self) -> None:
+        fam = self._make_two_param_family()
+        with pytest.raises(ValueError, match="Unknown parametrization 'nonexistent'"):
+            fam.view(parametrization_name="nonexistent")
+
+    def test_unexpected_free_parameter_raises_type_error(self) -> None:
+        fam = self._make_two_param_family()
+        partial = fam.view(a=1.0)
+        with pytest.raises(TypeError, match="got unexpected keyword argument"):
+            partial.distribution(unknown=42)


### PR DESCRIPTION
Add `view` method for partial parameter fixing.

This PR introduces a `view` method that fixes a subset of parameters in any parametrization,
returning a `PartialParametricFamily` (a genuine `ParametricFamily` subclass).
The view exposes only the fixed parametrization as its local base, keeps all analytical
characteristics (via conversion to the original base when needed), and behaves like a
normal one‑parametrization family with fixed‑parameter metadata.

Example:
```python
norm = ParametricFamilyRegister.get("normal") 
norm_std1 = norm.view(parametrization_name="meanStd", std=1.0)          # fix std, mean is a variable
dist = norm_std1.distribution(mean=0.0) # Normal(0,1)