### PR TITLE
Fix release workflow display names and license badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: ${{ github.event_name == 'workflow_dispatch' && 'Release TestPyPI' || format('Release {0} PyPI', github.ref_name) }}
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [status-shield]: https://github.com/PySATL/pysatl-core/actions/workflows/ci.yml/badge.svg?branch=main&event=push
 [status-url]: https://github.com/PySATL/pysatl-core/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush
-[license-shield]: https://img.shields.io/github/license/PySATL/pysatl-core.svg?style=for-the-badge&color=blue
+[license-shield]: https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge
 [license-url]: LICENSE
 
 [![CI][status-shield]][status-url]


### PR DESCRIPTION
## Summary

Clean up release workflow naming and fix the license badge shown in the README.

## Changes

- Add an explicit `run-name` to the release workflow:
  - manual TestPyPI runs are shown as `Release TestPyPI`;
  - tag-based PyPI runs are shown as `Release <tag> PyPI`.
- Replace the dynamic GitHub license shield with a static MIT badge.

## Notes

GitHub already recognizes the repository `LICENSE` file as MIT. The `INVALID` label came from the README badge provider, not from the actual license file.

The workflow naming change applies to future release workflow runs only.